### PR TITLE
✨ Updated .gitignore and improved include paths for better organizati…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 jetpack_server
 jetpack_client
+.idea
+.vscode
+*.o
+*.a
+vg*

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ MAIN_CLIENT_OBJ		=	$(MAIN_CLIENT_SRC:.cpp=.o)
 
 TESTS_SRC			=
 
-INCLUDES			=	-I ./src/shared/parsing -I ./src/shared/socket -I ./src/shared/utility
+INCLUDES			=	-I ./src/shared/parsing -I ./src/shared/socket	\
+						-I ./src/shared/utility
 
 CPPFLAGS			+=	-std=c++20 -Wall -Wextra -Werror $(INCLUDES) -O2 -g
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ MAIN_CLIENT_OBJ		=	$(MAIN_CLIENT_SRC:.cpp=.o)
 TESTS_SRC			=
 
 INCLUDES			=	-I ./src/shared/parsing -I ./src/shared/socket	\
-						-I ./src/shared/utility
+						-I ./src/shared/utility -I ./src/server/pollfdlist	\
+						-I ./src/server/client
 
 CPPFLAGS			+=	-std=c++20 -Wall -Wextra -Werror $(INCLUDES) -O2 -g
 

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,11 @@
 %.o: %.cpp
 	g++ $(CPPFLAGS) -c $< -o $@
 
-# Shared ressources
 SHARED_SRC			=	./src/shared/parsing/Parser.cpp						\
 						./src/shared/socket/Socket.cpp						\
 
 SHARED_OBJ			=	$(SHARED_SRC:.cpp=.o)
 
-# Server ressources
 SERVER_BINARY_NAME	=	jetpack_server
 
 MAIN_SERVER_SRC		=	./src/server/main.cpp
@@ -29,7 +27,6 @@ SERVER_OBJ			=	$(SERVER_SRC:.cpp=.o)
 
 MAIN_SERVER_OBJ		=	$(MAIN_SERVER_SRC:.cpp=.o)
 
-# Client ressources
 CLIENT_BINARY_NAME	=	jetpack_client
 
 MAIN_CLIENT_SRC		=	./src/client/main.cpp
@@ -40,11 +37,9 @@ CLIENT_OBJ			=	$(CLIENT_SRC:.cpp=.o)
 
 MAIN_CLIENT_OBJ		=	$(MAIN_CLIENT_SRC:.cpp=.o)
 
-# Tests ressources
 TESTS_SRC			=
 
-# Flags
-INCLUDES			=	-I ./src -I ./
+INCLUDES			=	-I ./src/shared/parsing -I ./src/shared/socket -I ./src/shared/utility
 
 CPPFLAGS			+=	-std=c++20 -Wall -Wextra -Werror $(INCLUDES) -O2 -g
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ $(CPPTESTFLAGS)
 
 clean:
 	rm -f $(SERVER_OBJ) $(MAIN_SERVER_OBJ) $(SHARED_OBJ)
+	rm -f $(CLIENT_OBJ) $(MAIN_CLIENT_OBJ) $(SHARED_OBJ)
 	rm -f *.gcda
 	rm -f *.gcno
 	rm -f vgcore.*

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -7,8 +7,7 @@
 
 #include <string>
 #include <iostream>
-#include "./src/shared/parsing/Parser.hpp"
-// #include "./client/src/client/Client.hpp"
+#include "Parser.hpp"
 
 int main(int argc, char **argv) {
     jetpack::Parser parser(argc, argv);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -10,8 +10,8 @@
 #include <unistd.h>
 #include <string>
 #include <iostream>
-#include "./src/shared/socket/Socket.hpp"
-#include "./src/server/Server.hpp"
+#include "Socket.hpp"
+#include "Server.hpp"
 
 volatile sig_atomic_t stopFlag = 0;
 

--- a/src/server/Server.hpp
+++ b/src/server/Server.hpp
@@ -11,9 +11,9 @@
     #include <memory>
     #include <vector>
     #include <string>
-    #include "./src/shared/socket/Socket.hpp"
-    #include "./src/server/pollfdlist/PollFdList.hpp"
-    #include "./src/server/client/Client.hpp"
+    #include "Socket.hpp"
+    #include "PollFdList.hpp"
+    #include "Client.hpp"
     #define LISTEN_BACKLOG 128
 
 namespace jetpack {

--- a/src/server/client/Client.cpp
+++ b/src/server/client/Client.cpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 #include <string>
-#include "./src/server/client/Client.hpp"
+#include "Client.hpp"
 
 // Helper functions -----------------------------------------------------------
 

--- a/src/server/client/Client.hpp
+++ b/src/server/client/Client.hpp
@@ -12,7 +12,7 @@
     #include <unordered_map>
     #include <memory>
     #include <string>
-    #include "./src/shared/socket/Socket.hpp"
+    #include "Socket.hpp"
 
 namespace jetpack {
 namespace server {

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -6,8 +6,8 @@
 */
 
 #include <iostream>
-#include "./src/server/Server.hpp"
-#include "./src/shared/parsing/Parser.hpp"
+#include "Server.hpp"
+#include "Parser.hpp"
 
 int main(int argc, char **argv) {
     jetpack::Parser parser(argc, argv);

--- a/src/server/pollfdlist/PollFdList.cpp
+++ b/src/server/pollfdlist/PollFdList.cpp
@@ -5,7 +5,7 @@
 ** PollFdList
 */
 
-#include "./src/server/pollfdlist/PollFdList.hpp"
+#include "PollFdList.hpp"
 
 jetpack::server::PollFdList::PollFdList(int serverSocket) {
     addSocket(serverSocket, POLLIN);

--- a/src/shared/parsing/Parser.cpp
+++ b/src/shared/parsing/Parser.cpp
@@ -9,7 +9,7 @@
 #include <arpa/inet.h>
 #include <iostream>
 #include <string>
-#include "./src/shared/parsing/Parser.hpp"
+#include "Parser.hpp"
 
 jetpack::Parser::Parser(int argc, char **argv) :
     _args(argv, argv + argc), _argc(argc) {

--- a/src/shared/socket/Socket.cpp
+++ b/src/shared/socket/Socket.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include "./src/shared/socket/Socket.hpp"
+#include "Socket.hpp"
 
 Socket::Socket(int fd, struct sockaddr_in address) noexcept :
     _closeSocketOnDestruction(false) {

--- a/src/shared/utility/ToBytes.hpp
+++ b/src/shared/utility/ToBytes.hpp
@@ -10,6 +10,7 @@
 
     #include <vector>
     #include <cstdint>
+    #include <cstring>
 
 namespace jetpack {
 template <typename T>


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` and multiple source files to improve the include paths and update the `INCLUDES` flags. The most important changes include updating include paths in various source files and modifying the `Makefile` to reflect these changes.

Changes to include paths:

* [`src/client/main.cpp`](diffhunk://#diff-0ba42df560ab77c250cbab896ad90bd4f63568ff1fa11b5e2ee8eddfd2ed964dL10-R10): Updated the include paths for `Parser.hpp` to use a relative path without the `./src/shared/parsing/` prefix.
* [`src/server/Server.cpp`](diffhunk://#diff-fe6a425046d31a4a2e8dba203e54ae8c9383c2bf59c9d07f685e15d170bcd097L13-R14): Updated the include paths for `Socket.hpp` and `Server.hpp` to use relative paths without the `./src/shared/socket/` and `./src/server/` prefixes.
* [`src/server/Server.hpp`](diffhunk://#diff-3b795d5647dbf91c8728160438b7c68c4a696298857e5303dbd377efcca53a9eL14-R16): Updated the include paths for `Socket.hpp`, `PollFdList.hpp`, and `Client.hpp` to use relative paths without the `./src/shared/socket/` and `./src/server/` prefixes.
* [`src/server/client/Client.cpp`](diffhunk://#diff-4c30efdb1297cc9c1c906a60f8faa372fdfdbd7195c5053731f216576a7e22edL10-R10): Updated the include path for `Client.hpp` to use a relative path without the `./src/server/client/` prefix.
* [`src/server/client/Client.hpp`](diffhunk://#diff-5ecaa45c33101a93dabc20c38a6d9e0549951d0647c9468390f9853cae8c4d90L15-R15): Updated the include path for `Socket.hpp` to use a relative path without the `./src/shared/socket/` prefix.
* [`src/server/pollfdlist/PollFdList.cpp`](diffhunk://#diff-9c376ea960758bf20fb27715a6cd4d827ea9160deee8f6d0e6223b66dfa7d426L8-R8): Updated the include path for `PollFdList.hpp` to use a relative path without the `./src/server/pollfdlist/` prefix.

Changes to `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L43-R42): Updated `INCLUDES` flags to include specific directories (`./src/shared/parsing`, `./src/shared/socket`, `./src/shared/utility`) instead of the previous general includes.