### PR TITLE
Adding a start button

### DIFF
--- a/src/client/Game/GameGraphic.cpp
+++ b/src/client/Game/GameGraphic.cpp
@@ -57,7 +57,6 @@ void jetpack::Client::Game::_handleKeyPressed(const sf::Event &event) {
 
 void jetpack::Client::Game::_handleKeyRelease(const sf::Event &event) {
     if (event.key.code == sf::Keyboard::Up) {
-        std::cout << "GROS CACA" << std::endl;
         this->_sendUserInteraction(UserInteractions_s::NO_INTERACTION);
     }
     // TODO(noa) : demander les autres interaction possible entre le

--- a/src/client/Graphic.cpp
+++ b/src/client/Graphic.cpp
@@ -127,12 +127,13 @@ jetpack::Client::Graphic::Graphic(
     std::function<std::pair<std::string, std::string>()> &getSocketSettings,
     std::function<void(std::pair<std::string, int>)> &sendSocketSetting,
     std::function<int()> &getIdWithAuth,
-    std::function<bool()> &getIsConnectedWithAuth)
+    std::function<bool()> &getIsConnectedWithAuth,
+    std::function<void()> &sendStartGame)
     : _window(sf::VideoMode({1440, 550}), "Jetpack Joyride",
               sf::Style::Close | sf::Style::Titlebar),
       _getIdWithAuth(getIdWithAuth),
       _menu(changeUsername, getUsername, getSocketSettings, sendSocketSetting,
-            getIdWithAuth, getIsConnectedWithAuth),
+            getIdWithAuth, getIsConnectedWithAuth, sendStartGame),
       _game(sendUserInteraction) {
     this->_windowType = MENU;
     this->_window.setFramerateLimit(144);

--- a/src/client/Graphic.hpp
+++ b/src/client/Graphic.hpp
@@ -86,7 +86,8 @@ class Graphic {
         std::function<std::pair<std::string, std::string>()> &getSocketSettings,
         std::function<void(std::pair<std::string, int>)> &sendSocketSetting,
         std::function<int()> &getIdWithAuth,
-        std::function<bool()> &getIsConnectedWithAuth);
+        std::function<bool()> &getIsConnectedWithAuth,
+        std::function<void()> &sendStartGame);
 
     ~Graphic() = default;
 };

--- a/src/client/Menu/MenuGraphic.cpp
+++ b/src/client/Menu/MenuGraphic.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <utility>
+#include <iostream>
 
 void jetpack::Client::Menu::_handleMousePressed(const sf::Event &event) {
     if (event.mouseButton.button == sf::Mouse::Left) {
@@ -18,6 +19,7 @@ void jetpack::Client::Menu::_handleMousePressed(const sf::Event &event) {
                 this->_usernameTextButton.setString("Close");
                 this->_usernameButton.setSize({105, 70});
                 this->_settingsButton.setFillColor(sf::Color(71, 71, 70));
+                this->_startButton.setFillColor(sf::Color(71, 71, 70));
             } else {
                 if (!this->_username.empty() &&
                     this->_getUsername() != this->_username)
@@ -25,6 +27,7 @@ void jetpack::Client::Menu::_handleMousePressed(const sf::Event &event) {
                 this->_usernameTextButton.setString("Change Username");
                 this->_usernameButton.setSize({250, 70});
                 this->_settingsButton.setFillColor(this->_menuButtonColor);
+                this->_startButton.setFillColor(this->_menuButtonColor);
             }
         }
         if (!this->_isUserNamePressed &&
@@ -36,6 +39,7 @@ void jetpack::Client::Menu::_handleMousePressed(const sf::Event &event) {
                 this->_settingsTextButton.setString("Close");
                 this->_settingsButton.setSize({105, 70});
                 this->_usernameButton.setFillColor(sf::Color(71, 71, 70));
+                this->_startButton.setFillColor(sf::Color(71, 71, 70));
             } else {
                 this->_sendSocketSettings(
                     {this->_ipBoxContent.getString(),
@@ -45,8 +49,17 @@ void jetpack::Client::Menu::_handleMousePressed(const sf::Event &event) {
                 this->_settingsTextButton.setString("Settings");
                 this->_settingsButton.setSize({140, 70});
                 this->_usernameButton.setFillColor(this->_menuButtonColor);
+                this->_startButton.setFillColor(this->_menuButtonColor);
             }
         }
+
+        if (!this->_isUserNamePressed && !this->_isSettingsPressed &&
+            this->_startButton.getGlobalBounds().contains(
+                static_cast<float>(event.mouseButton.x),
+                static_cast<float>(event.mouseButton.y))) {
+            this->_sendStartServer();
+        }
+
         if (this->_isSettingsPressed &&
             this->_ipField.getGlobalBounds().contains(
                 static_cast<float>(event.mouseButton.x),
@@ -76,6 +89,8 @@ void jetpack::Client::Menu::display(sf::RenderWindow &window) {
     window.draw(this->_usernameTextButton);
     window.draw(this->_settingsButton);
     window.draw(this->_settingsTextButton);
+    window.draw(this->_startButton);
+    window.draw(this->_startTextButton);
     if (this->_isUserNamePressed) {
         window.draw(this->_usernameBox);
         window.draw(this->_usernameBoxTitle);
@@ -173,13 +188,15 @@ jetpack::Client::Menu::Menu(
     std::function<std::pair<std::string, std::string>()> &getSocketSettings,
     std::function<void(std::pair<std::string, int>)> &sendSocketSettings,
     std::function<int()> &getIdWithAuth,
-    std::function<bool()> &getIsConnectedWithAuth)
+    std::function<bool()> &getIsConnectedWithAuth,
+    std::function<void()> &sendStartServer)
     : _changeUsername(changeUsername),
       _getUsername(getUsername),
       _authIsConnected(getIsConnectedWithAuth),
       _authGetId(getIdWithAuth),
       _getSocketSettings(getSocketSettings),
-      _sendSocketSettings(sendSocketSettings) {
+      _sendSocketSettings(sendSocketSettings),
+      _sendStartServer(sendStartServer) {
     if (!this->_menuBackgroundTexture.loadFromFile("src/client/assets/"
                                                    "MenuBackground.png")) {
         throw std::runtime_error(
@@ -346,6 +363,20 @@ jetpack::Client::Menu::Menu(
     this->_blurShader.setUniform("sigma", 5.f);
     this->_blurShader.setUniform("direction", sf::Vector2f(0.f, 1.f));
     this->_blurShader.setUniform("resolution", sf::Vector2f(1440.f, 550.f));
+
+    this->_startTextButton.setFont(this->_jetpackFont);
+    this->_startTextButton.setString("Start");
+    this->_startTextButton.setCharacterSize(30);
+    this->_startTextButton.setFillColor(this->_menuButtonTextColor);
+    this->_startTextButton.setOutlineThickness(3);
+    this->_startTextButton.setOutlineColor(sf::Color::Black);
+    this->_startTextButton.setPosition({52, 190});
+
+    this->_startButton.setPosition({20, 180});
+    this->_startButton.setSize({140, 60});
+    this->_startButton.setFillColor(this->_menuButtonColor);
+    this->_startButton.setOutlineColor(sf::Color::Black);
+    this->_startButton.setOutlineThickness(4);
 
     this->_menuBackground = sf::Sprite(this->_menuBackgroundTexture);
 }

--- a/src/client/Menu/MenuGraphic.hpp
+++ b/src/client/Menu/MenuGraphic.hpp
@@ -51,6 +51,9 @@ class Menu {
     sf::Text _portBoxContent;
     sf::Text _portBoxTitle;
 
+    sf::Text _startTextButton;
+    sf::RectangleShape _startButton;
+
     sf::Text _serverStateText;
     std::string _serverStateString = "OK";
 
@@ -62,6 +65,7 @@ class Menu {
     std::function<int()> &_authGetId;
     std::function<std::pair<std::string, std::string>()> &_getSocketSettings;
     std::function<void(std::pair<std::string, int>)> &_sendSocketSettings;
+    std::function<void()> &_sendStartServer;
 
  public:
     void setServerStateError();
@@ -80,7 +84,8 @@ class Menu {
         std::function<std::pair<std::string, std::string>()> &getSocketSettings,
         std::function<void(std::pair<std::string, int>)> &sendSocketSettings,
         std::function<int()> &getIdWithAuth,
-        std::function<bool()> &getIsConnectedWithAuth);
+        std::function<bool()> &getIsConnectedWithAuth,
+        std::function<void()> &sendStartServer);
 
     ~Menu() = default;
 };

--- a/src/client/ProgramGraphic.cpp
+++ b/src/client/ProgramGraphic.cpp
@@ -167,7 +167,8 @@ void jetpack::Client::Program::_getServerMessage() {
     }
 }
 
-void jetpack::Client::Program::_connectToSocket(const char *ip, unsigned int port) {
+void jetpack::Client::Program::_connectToSocket(const char *ip,
+    unsigned int port) {
     if (this->_socket.getSocketFd() != -1) {
         this->_socket.closeSocket();
     }
@@ -183,7 +184,7 @@ void jetpack::Client::Program::_connectToSocket(const char *ip, unsigned int por
         this->_auth.resetAuth();
         this->_manualReco = true;
         this->_logger.log("Connection failed: " + std::string(e.what()));
-        throw; // Relancer pour que _sniffANetwork puisse gérer les tentatives
+        throw;
     }
 }
 

--- a/src/client/ProgramGraphic.cpp
+++ b/src/client/ProgramGraphic.cpp
@@ -378,7 +378,7 @@ jetpack::Client::Program::Program(const char *ip, unsigned int port,
       _graphic(this->_sendUserInteraction, this->_changeUsername,
                this->_getUsername, this->_getSocketSettings,
                this->_setSocketSettings, this->_getIdWithAuth,
-               this->_getIsConnectedWithAuth),
+               this->_getIsConnectedWithAuth, this->_sendStartGame),
       _socket(AF_INET, SOCK_STREAM, 0) {
     this->_port = port;
     this->_logger.log("Connecting to " + this->_ip +

--- a/src/client/ProgramGraphic.cpp
+++ b/src/client/ProgramGraphic.cpp
@@ -41,10 +41,12 @@ void jetpack::Client::Program::_setSize_tData(std::vector<unsigned char> msg) {
     }
 }
 
-float readBigEndianFloat(const std::vector<unsigned char> &data,
-                         size_t offset) {
-    uint32_t asInt = (data[offset] << 24) | (data[offset + 1] << 16) |
-                     (data[offset + 2] << 8) | data[offset + 3];
+float readBigEndianFloat(const std::vector<unsigned char>& data,
+    size_t offset) {
+    uint32_t asInt = (data[offset] << 24) |
+                     (data[offset + 1] << 16) |
+                     (data[offset + 2] << 8) |
+                     data[offset + 3];
     float result;
     std::memcpy(&result, &asInt, sizeof(result));
     return result;
@@ -53,7 +55,7 @@ float readBigEndianFloat(const std::vector<unsigned char> &data,
 void jetpack::Client::Program::_setPlayerData(std::vector<unsigned char> msg) {
     if (msg.size() < 35) {
         this->_logger.log("Invalid player data size: " +
-                          std::to_string(msg.size()));
+            std::to_string(msg.size()));
         return;
     }
     player_t player;
@@ -70,8 +72,8 @@ void jetpack::Client::Program::_setPlayerData(std::vector<unsigned char> msg) {
                  sizeof(player.username) - 1);
     player.username[sizeof(player.username) - 1] = '\0';
     player.y_pos = readBigEndianFloat(msg, 24);
-    player.coins_collected =
-        (msg[28] << 24) | (msg[29] << 16) | (msg[30] << 8) | msg[31];
+    player.coins_collected = (msg[28] << 24) | (msg[29] << 16)
+        | (msg[30] << 8) | msg[31];
     player.is_dead = msg[32] != 0;
     player.is_jetpack_on = msg[33] != 0;
     player.host = msg[34] != 0;
@@ -83,7 +85,7 @@ void jetpack::Client::Program::_setPlayerData(std::vector<unsigned char> msg) {
     this->_logger.log("Player is dead: " + std::to_string(player.is_dead));
     this->_logger.log("Player is host: " + std::to_string(player.host));
     this->_logger.log("Player is jetpack on: " +
-                      std::to_string(player.is_jetpack_on));
+        std::to_string(player.is_jetpack_on));
     this->_graphic.addNewPlayer(player.id, this->_auth.getId() == player.id);
     this->_graphic.setPosPlayer(player.id,
                                 sf::Vector2f(90, player.y_pos * 39.f + 90.f));

--- a/src/client/ProgramGraphic.cpp
+++ b/src/client/ProgramGraphic.cpp
@@ -184,7 +184,6 @@ void jetpack::Client::Program::_connectToSocket(const char *ip,
         this->_auth.resetAuth();
         this->_manualReco = true;
         this->_logger.log("Connection failed: " + std::string(e.what()));
-        throw;
     }
 }
 

--- a/src/client/ProgramGraphic.hpp
+++ b/src/client/ProgramGraphic.hpp
@@ -34,6 +34,8 @@ class Program {
     std::mutex _userInteractionMutex;
     UserInteractions_s _lastUserInteraction =
         UserInteractions_s::NO_INTERACTION;
+    StartGame_s _startGameInteraction =
+        StartGame_s::NOTHING;
     bool _isChangeUsername = false;
 
     Auth _auth;
@@ -47,6 +49,13 @@ class Program {
             this->_lastUserInteraction = data;
             this->_userInteractionMutex.unlock();
         });
+
+    std::function<void()> _sendStartGame =
+    ([this]() {
+        this->_userInteractionMutex.lock();
+        this->_startGameInteraction = START;
+        this->_userInteractionMutex.unlock();
+    });
 
     std::function<void(std::string)> _changeUsername =
         ([this](std::string username) {

--- a/src/client/ProgramGraphic.hpp
+++ b/src/client/ProgramGraphic.hpp
@@ -117,7 +117,11 @@ class Program {
 
     void _sendEmptyEvent();
 
+    void _sendStartEvent();
+
     void _sendPlayerInput();
+
+    void _sendStartInput();
 
     void _sendNewUsername();
 

--- a/src/client/userInteractions.hpp
+++ b/src/client/userInteractions.hpp
@@ -6,9 +6,13 @@
 #define SRC_CLIENT_USERINTERACTIONS_HPP_
 
 namespace jetpack::Client {
-enum UserInteractions_s {
-    UP,
-    NO_INTERACTION,
-};
+    enum UserInteractions_s {
+        UP,
+        NO_INTERACTION,
+    };
+    enum StartGame_s {
+        START,
+        NOTHING,
+    };
 }
 #endif  // SRC_CLIENT_USERINTERACTIONS_HPP_

--- a/src/client/userInteractions.hpp
+++ b/src/client/userInteractions.hpp
@@ -6,13 +6,13 @@
 #define SRC_CLIENT_USERINTERACTIONS_HPP_
 
 namespace jetpack::Client {
-    enum UserInteractions_s {
-        UP,
-        NO_INTERACTION,
-    };
-    enum StartGame_s {
-        START,
-        NOTHING,
-    };
+enum UserInteractions_s {
+    UP,
+    NO_INTERACTION,
+};
+enum StartGame_s {
+    START,
+    NOTHING,
+};
 }
 #endif  // SRC_CLIENT_USERINTERACTIONS_HPP_

--- a/src/shared/utility/NetworksUtils.cpp
+++ b/src/shared/utility/NetworksUtils.cpp
@@ -91,10 +91,13 @@ jetpack::Header_t getHeader(jetpack::Logger &logger, Socket &socket) {
     std::vector<unsigned char> headerBuffer;
     headerBuffer.resize(2);
     headerBuffer = socket.readFromSocket(2);
-    if (headerBuffer.empty() ||
-        headerBuffer == std::vector<unsigned char>(2, 0)) {
-        logger.log("Header Error or Server disconnected");
+    if (headerBuffer.empty()) {
+        logger.log("Server disconnected");
         throw HeaderException("Incomplete Header size = 0");
+    }
+    if (headerBuffer == std::vector<unsigned char>(2, 0)) {
+        logger.log("Header Error 2 bytes == 0");
+        throw HeaderException("Incomplete Header 2 bytes == 0");
     }
     if (headerBuffer.size() < 2) {
         logger.log("Incomplete Header");


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the client-side codebase for the Jetpack Joyride application. The most significant changes include adding functionality for starting a game through the UI, improving socket handling, and refining network communication. Additionally, some minor code cleanup and formatting adjustments have been made.

### New Game Start Functionality:
* Added a "Start" button to the menu UI, including its visual properties and event handling logic in `MenuGraphic.cpp`. This button triggers the `sendStartServer` function when clicked. (`[[1]](diffhunk://#diff-6b1d47284d7e90233bd238d6e2cc7d33d9d02d382339f8e5434f2b47e67dcdf7R22-R30)`, `[[2]](diffhunk://#diff-6b1d47284d7e90233bd238d6e2cc7d33d9d02d382339f8e5434f2b47e67dcdf7R42)`, `[[3]](diffhunk://#diff-6b1d47284d7e90233bd238d6e2cc7d33d9d02d382339f8e5434f2b47e67dcdf7R52-R62)`, `[[4]](diffhunk://#diff-6b1d47284d7e90233bd238d6e2cc7d33d9d02d382339f8e5434f2b47e67dcdf7R92-R93)`, `[[5]](diffhunk://#diff-6b1d47284d7e90233bd238d6e2cc7d33d9d02d382339f8e5434f2b47e67dcdf7R367-R380)`, `[[6]](diffhunk://#diff-7882d7843b3fb1daf590b2fba3c7afa0c391b6bdc4eb37e316d278cf3ae5e6c8R54-R56)`, `[[7]](diffhunk://#diff-7882d7843b3fb1daf590b2fba3c7afa0c391b6bdc4eb37e316d278cf3ae5e6c8R68)`, `[[8]](diffhunk://#diff-7882d7843b3fb1daf590b2fba3c7afa0c391b6bdc4eb37e316d278cf3ae5e6c8L83-R88)`)
* Updated the `Menu` and `Graphic` constructors to include the `sendStartServer` and `sendStartGame` callbacks for handling the start game interaction. (`[[1]](diffhunk://#diff-582f4c6ec80dfa3b98365b128f8d2234c0c6e9c3da76fafd47787b155fb7d715L130-R136)`, `[[2]](diffhunk://#diff-d7bee0bf652b4ef3317af9280f3ca1626918acf515e3e0c783155860fc755250L89-R90)`, `[[3]](diffhunk://#diff-6b1d47284d7e90233bd238d6e2cc7d33d9d02d382339f8e5434f2b47e67dcdf7L176-R199)`, `[[4]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L379-R413)`)

### Networking Improvements:
* Introduced `_sendStartEvent` and `_sendStartInput` methods in `ProgramGraphic.cpp` to handle sending "start game" events to the server. (`[[1]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7R320-R332)`, `[[2]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L325-R368)`)
* Enhanced socket management by ensuring the socket is closed before resetting it during reconnections. (`[src/client/ProgramGraphic.cppR172-R174](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7R172-R174)`)
* Adjusted the polling timeout in `_sniffANetwork` for more responsive network communication. (`[src/client/ProgramGraphic.cppL241-R246](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L241-R246)`)
* Improved error handling for header parsing in `NetworksUtils.cpp` to differentiate between server disconnections and header errors. (`[src/shared/utility/NetworksUtils.cppL94-R101](diffhunk://#diff-f617492da8bd6c080ee271242b4aa7c49d91672c808fe81f4417ff9aabbf669eL94-R101)`)

### Code Cleanup and Refactoring:
* Removed an unnecessary debug message from `_handleKeyRelease` in `GameGraphic.cpp`. (`[src/client/Game/GameGraphic.cppL60](diffhunk://#diff-ecdea2f9eb63fbd45854d90a0330b6bb015a945e642f3ab65c445e44dfceb290L60)`)
* Reformatted code for better readability in `ProgramGraphic.cpp`, including adjustments to bitwise operations and line breaks. (`[[1]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L46-R49)`, `[[2]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L73-R76)`)

### New Enums and State Management:
* Added a new `StartGame_s` enum to represent the state of the start game interaction. (`[[1]](diffhunk://#diff-691055f48b7b62dfb32735e5f81c61ea9feef9bd1b4d8208a91471253fad4309R13-R16)`, `[[2]](diffhunk://#diff-ac588d126c28aefbf18fc337b9d1a1da6b8d01dd9748d4310a2899ed0d43f823R37-R38)`)
* Integrated `StartGame_s` into the `Program` class to track and handle game start requests. (`[[1]](diffhunk://#diff-ac588d126c28aefbf18fc337b9d1a1da6b8d01dd9748d4310a2899ed0d43f823R53-R59)`, `[[2]](diffhunk://#diff-ac588d126c28aefbf18fc337b9d1a1da6b8d01dd9748d4310a2899ed0d43f823R120-R125)`)