### PR TITLE
:sparkles: Add EndGame functionality and integrate player status mana…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ CLIENT_SRC			=	./src/client/Graphic.cpp							\
 						./src/client/Coin/CoinGraphic.cpp					\
 						./src/client/CoinStats/CoinStats.cpp				\
 						./src/client/Laser/LaserGraphic.cpp					\
+						./src/client/EndGame/EndGame.cpp					\
 
 CLIENT_OBJ			=	$(CLIENT_SRC:.cpp=.o)
 

--- a/src/client/EndGame/EndGame.cpp
+++ b/src/client/EndGame/EndGame.cpp
@@ -3,6 +3,10 @@
 //
 
 #include "EndGame.hpp"
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 void jetpack::Client::EndGame::resetEndGameClock() {
     this->_endGameClock.restart();
@@ -12,7 +16,8 @@ void jetpack::Client::EndGame::display(sf::RenderWindow &window) {
     window.draw(this->_text);
 }
 
-void jetpack::Client::EndGame::compute(int id,  const std::map<unsigned int, std::pair<std::unique_ptr<Player>, sf::Vector2f>> &listPlayer) {
+void jetpack::Client::EndGame::compute(int id,  const std::map<unsigned int,
+    std::pair<std::unique_ptr<Player>, sf::Vector2f>> &listPlayer) {
     if (this->_endGameClock.getElapsedTime().asSeconds() <= 5) {
         this->_switchToMenu();
     }
@@ -22,7 +27,8 @@ void jetpack::Client::EndGame::compute(int id,  const std::map<unsigned int, std
             idDeadPlayer.push_back(s.first);
     }
     if (!idDeadPlayer.empty()) {
-        bool isCurrentPlayerDead = std::find(idDeadPlayer.begin(), idDeadPlayer.end(), id) != idDeadPlayer.end();
+        bool isCurrentPlayerDead = std::find(idDeadPlayer.begin(),
+            idDeadPlayer.end(), id) != idDeadPlayer.end();
 
         if (isCurrentPlayerDead)
             this->_text.setString("You Lost!");
@@ -33,8 +39,8 @@ void jetpack::Client::EndGame::compute(int id,  const std::map<unsigned int, std
     }
 }
 
-jetpack::Client::EndGame::EndGame(std::function<void()> &switchToMenu) : _switchToMenu(switchToMenu)
-{
+jetpack::Client::EndGame::EndGame(std::function<void()> &switchToMenu) :
+    _switchToMenu(switchToMenu) {
     if (!this->_font.loadFromFile("src/client/assets/JetpackFont.ttf")) {
         throw std::runtime_error("Erreur : Impossible de charger la police"
             "JetpackFont.ttf");

--- a/src/client/EndGame/EndGame.cpp
+++ b/src/client/EndGame/EndGame.cpp
@@ -1,0 +1,48 @@
+//
+// Created by roussierenoa on 4/18/25.
+//
+
+#include "EndGame.hpp"
+
+void jetpack::Client::EndGame::resetEndGameClock() {
+    this->_endGameClock.restart();
+}
+
+void jetpack::Client::EndGame::display(sf::RenderWindow &window) {
+    window.draw(this->_text);
+}
+
+void jetpack::Client::EndGame::compute(int id,  const std::map<unsigned int, std::pair<std::unique_ptr<Player>, sf::Vector2f>> &listPlayer) {
+    if (this->_endGameClock.getElapsedTime().asSeconds() <= 5) {
+        this->_switchToMenu();
+    }
+    std::vector<unsigned int> idDeadPlayer = {};
+    for (auto &s : listPlayer) {
+        if (s.second.first->isDead() == true)
+            idDeadPlayer.push_back(s.first);
+    }
+    if (!idDeadPlayer.empty()) {
+        bool isCurrentPlayerDead = std::find(idDeadPlayer.begin(), idDeadPlayer.end(), id) != idDeadPlayer.end();
+
+        if (isCurrentPlayerDead)
+            this->_text.setString("You Lost!");
+        else
+            this->_text.setString("You Won!");
+    } else {
+        this->_text.setString("Draw!");
+    }
+}
+
+jetpack::Client::EndGame::EndGame(std::function<void()> &switchToMenu) : _switchToMenu(switchToMenu)
+{
+    if (!this->_font.loadFromFile("src/client/assets/JetpackFont.ttf")) {
+        throw std::runtime_error("Erreur : Impossible de charger la police"
+            "JetpackFont.ttf");
+    }
+    this->_text.setCharacterSize(50);
+    this->_text.setFillColor(sf::Color::White);
+    this->_text.setFont(this->_font);
+}
+
+jetpack::Client::EndGame::~EndGame() {
+}

--- a/src/client/EndGame/EndGame.hpp
+++ b/src/client/EndGame/EndGame.hpp
@@ -1,0 +1,39 @@
+//
+// Created by roussierenoa on 4/18/25.
+//
+
+#ifndef ENDGAME_HPP
+#define ENDGAME_HPP
+
+#include <functional>
+#include <memory>
+#include <SFML/Graphics.hpp>
+#include "Player/PlayerGraphic.hpp"
+
+namespace jetpack::Client {
+class EndGame {
+ private:
+        sf::Clock _endGameClock;
+        sf::Text _text;
+        sf::Font _font;
+        sf::RenderWindow _window;
+
+        std::function<void()> &_switchToMenu;
+
+ public:
+
+        void resetEndGameClock();
+
+        void display(sf::RenderWindow &window);
+
+        void compute(int id, const std::map<unsigned int, std::pair<std::unique_ptr<Player>, sf::Vector2f>> &listPlayer);
+
+        EndGame(std::function<void()> &switchToMenu);
+
+        ~EndGame();
+};
+}
+
+
+
+#endif //ENDGAME_HPP

--- a/src/client/EndGame/EndGame.hpp
+++ b/src/client/EndGame/EndGame.hpp
@@ -2,11 +2,14 @@
 // Created by roussierenoa on 4/18/25.
 //
 
-#ifndef ENDGAME_HPP
-#define ENDGAME_HPP
+#ifndef SRC_CLIENT_ENDGAME_ENDGAME_HPP_
+#define SRC_CLIENT_ENDGAME_ENDGAME_HPP_
 
 #include <functional>
 #include <memory>
+#include <map>
+#include <string>
+#include <utility>
 #include <SFML/Graphics.hpp>
 #include "Player/PlayerGraphic.hpp"
 
@@ -21,19 +24,19 @@ class EndGame {
         std::function<void()> &_switchToMenu;
 
  public:
-
         void resetEndGameClock();
 
         void display(sf::RenderWindow &window);
 
-        void compute(int id, const std::map<unsigned int, std::pair<std::unique_ptr<Player>, sf::Vector2f>> &listPlayer);
+        void compute(int id, const std::map<unsigned int,
+            std::pair<std::unique_ptr<Player>, sf::Vector2f>> &listPlayer);
 
-        EndGame(std::function<void()> &switchToMenu);
+        explicit EndGame(std::function<void()> &switchToMenu);
 
         ~EndGame();
 };
-}
+}  // namespace jetpack::Client
 
 
 
-#endif //ENDGAME_HPP
+#endif  // SRC_CLIENT_ENDGAME_ENDGAME_HPP_

--- a/src/client/Graphic.hpp
+++ b/src/client/Graphic.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <EndGame/EndGame.hpp>
 
 #include <SFML/Graphics.hpp>
 
@@ -29,6 +30,7 @@ class Graphic {
 
     WindowType _windowType;
     size_t _gameSpeed = 0;
+    bool _isEndGame = false;
 
     sf::RenderWindow _window;
     std::map<unsigned int, std::pair<std::unique_ptr<Player>, sf::Vector2f> >
@@ -43,6 +45,12 @@ class Graphic {
 
     Menu _menu;
     Game _game;
+    EndGame _endGame;
+
+    std::function<void()> _switchToMenuFct =
+    ([this]() {
+        this->switchToMenu();
+    });
 
  public:
     void display();
@@ -71,9 +79,13 @@ class Graphic {
 
     void addNewPlayer(unsigned int id, bool isCurrent);
 
+    void setPlayerStatus(unsigned int id, bool isDead);
+
     void switchToGame();
 
     void switchToMenu();
+
+    void switchToDeath();
 
     void serverError();
 

--- a/src/client/Graphic.hpp
+++ b/src/client/Graphic.hpp
@@ -43,14 +43,15 @@ class Graphic {
 
     std::function<int()> &_getIdWithAuth;
 
-    Menu _menu;
-    Game _game;
-    EndGame _endGame;
 
     std::function<void()> _switchToMenuFct =
     ([this]() {
         this->switchToMenu();
     });
+
+    Menu _menu;
+    Game _game;
+    EndGame _endGame;
 
  public:
     void display();

--- a/src/client/Player/PlayerGraphic.cpp
+++ b/src/client/Player/PlayerGraphic.cpp
@@ -48,8 +48,9 @@ void jetpack::Client::Player::setCoinsAmount(unsigned int coins) {
 }
 
 jetpack::Client::Player::Player(bool isPlayer, unsigned int id)
-    : _isHost(!isPlayer),
-      _player("./src/client/assets/player_sprite_sheet.png", {138, 135}, 6, 4,
+    :   _isHost(!isPlayer),
+        _isDead(false),
+        _player("./src/client/assets/player_sprite_sheet.png", {138, 135}, 6, 4,
               {0.282, 0.288}) {
     this->id = id;
     this->_pos = {0, 0};

--- a/src/client/Player/PlayerGraphic.hpp
+++ b/src/client/Player/PlayerGraphic.hpp
@@ -22,6 +22,7 @@ class Player {
     };
     PlayerSprite_t _currentSpriteState = RUNNING;
     bool _isHost = false;
+    bool _isDead = false;
     unsigned int _coinsAmount = 0;
     sf::Vector2f _pos;
     std::string _username;
@@ -40,11 +41,17 @@ class Player {
 
     bool isHost() const { return this->_isHost; }
 
+    bool isDead() const { return this->_isDead; }
+
     void display(sf::RenderWindow &window);
 
     void compute();
 
     void changePosValue(sf::Vector2f pos);
+
+    void setPlayerStatus(bool isDead) {
+        this->_isDead = isDead;
+    }
 
     explicit Player(bool isPlayer, unsigned int id);
 

--- a/src/client/ProgramGraphic.cpp
+++ b/src/client/ProgramGraphic.cpp
@@ -343,7 +343,6 @@ void jetpack::Client::Program::_sendPlayerInput() {
     this->_communicationMutex.lock();
     this->_userInteractionMutex.lock();
     try {
-
         if (this->_socket.getSocketFd() != -1 && this->_sendInputBool == true) {
             if (this->_lastUserInteraction == jetpack::Client::UP)
                 this->_sendUpEvent();

--- a/src/client/ProgramGraphic.hpp
+++ b/src/client/ProgramGraphic.hpp
@@ -37,6 +37,7 @@ class Program {
     StartGame_s _startGameInteraction =
         StartGame_s::NOTHING;
     bool _isChangeUsername = false;
+    bool _sendInputBool = false;
 
     Auth _auth;
     jetpack::Logger &_logger;

--- a/src/shared/utility/CommunicationHeader.hpp
+++ b/src/shared/utility/CommunicationHeader.hpp
@@ -25,6 +25,9 @@ enum PayloadType_t {
     HEALTHCHECK = 15,
     JETPACK_FORCE = 16,
     VELOCITY_LIMITS = 17,
+    GETNBPLAYER = 18,
+    NBPLAYER = 19,
+    ENDOFGAME = 20,
     INVALID
 };
 

--- a/src/shared/utility/NetworksUtils.cpp
+++ b/src/shared/utility/NetworksUtils.cpp
@@ -71,6 +71,12 @@ int getPayloadSize(unsigned char dataId) {
             return 4;
         case jetpack::PayloadType_t::VELOCITY_LIMITS:
             return 8;
+        case jetpack::PayloadType_t::GETNBPLAYER:
+            return 0;
+        case jetpack::PayloadType_t::NBPLAYER:
+            return 4;
+        case jetpack::PayloadType_t::ENDOFGAME:
+            return 0;
         default:
             return 0;
     }


### PR DESCRIPTION
This pull request introduces an "End Game" feature to the client-side of the application. It adds functionality to handle end-of-game scenarios, display appropriate messages, and transition back to the menu. The most significant changes include the addition of the `EndGame` class, integration of this class into the `Graphic` and `Program` classes, and support for new payload types related to the end-game state.

### New "End Game" Feature:

* **Addition of `EndGame` Class**:
  - Created a new `EndGame` class in `src/client/EndGame/EndGame.cpp` and `EndGame.hpp` to manage end-game logic, including displaying messages ("You Won!", "You Lost!", or "Draw!") based on player statuses. [[1]](diffhunk://#diff-6d66034c0f49439b0f50f4606ab0b9889a0b53ccca66b411d7ab571f2dc5dabcR1-R48) [[2]](diffhunk://#diff-7b6eff58e65f64ac2655d5680796618d8f1e80f5206e3daade09eea2f855838cR1-R39)
  - The class includes methods for resetting the end-game clock, computing the game result, and rendering the end-game message. [[1]](diffhunk://#diff-6d66034c0f49439b0f50f4606ab0b9889a0b53ccca66b411d7ab571f2dc5dabcR1-R48) [[2]](diffhunk://#diff-7b6eff58e65f64ac2655d5680796618d8f1e80f5206e3daade09eea2f855838cR1-R39)

* **Integration into `Graphic` Class**:
  - Added an `EndGame` instance to the `Graphic` class, along with methods to handle transitions (`switchToDeath`, `setPlayerStatus`, etc.). (Fdfc714dL104R150, [[1]](diffhunk://#diff-d7bee0bf652b4ef3317af9280f3ca1626918acf515e3e0c783155860fc755250R48-R53) [[2]](diffhunk://#diff-d7bee0bf652b4ef3317af9280f3ca1626918acf515e3e0c783155860fc755250R82-R89)
  - Updated the `display` and `compute` methods in `Graphic.cpp` to incorporate end-game logic when `_isEndGame` is true. [[1]](diffhunk://#diff-582f4c6ec80dfa3b98365b128f8d2234c0c6e9c3da76fafd47787b155fb7d715R21-R22) [[2]](diffhunk://#diff-582f4c6ec80dfa3b98365b128f8d2234c0c6e9c3da76fafd47787b155fb7d715R53-R54)

### Updates to Player and Program Logic:

* **Player Status Tracking**:
  - Added a `bool _isDead` property and corresponding getter/setter methods to the `Player` class to track whether a player is dead. [[1]](diffhunk://#diff-30d9fee55f1a6b45b74bb797e6a08acfcaa3c63424fcf1bc94fab52e521e9c03R52) [[2]](diffhunk://#diff-5ade2d65b7d4a3820e0e8b45c7a93a89f62779c008409e3dad112925bb2f8aeaR25) [[3]](diffhunk://#diff-5ade2d65b7d4a3820e0e8b45c7a93a89f62779c008409e3dad112925bb2f8aeaR44-R55)

* **Program Enhancements**:
  - Modified the `Program` class to handle the new `ENDOFGAME` payload type, triggering the transition to the end-game state. [[1]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L163-R173) [[2]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L337-R347)
  - Introduced a `bool _sendInputBool` flag to control input sending during the end-game state. [[1]](diffhunk://#diff-ca999d8aeb64f8bbefc6a6df56725dd0d794fbd6b3727099171d46c6addc1cb7L337-R347) [[2]](diffhunk://#diff-ac588d126c28aefbf18fc337b9d1a1da6b8d01dd9748d4310a2899ed0d43f823R40)

### Communication Updates:

* **New Payload Types**:
  - Added `GETNBPLAYER`, `NBPLAYER`, and `ENDOFGAME` payload types to the `PayloadType_t` enum and updated `getPayloadSize` to support these types. [[1]](diffhunk://#diff-89eba4ee90f86ed3167293173d62feef1f24116d1dac016778fcd87433888d3eR28-R30) [[2]](diffhunk://#diff-f617492da8bd6c080ee271242b4aa7c49d91672c808fe81f4417ff9aabbf669eR74-R79)…gement